### PR TITLE
Scope past/active trip indicators to the selected schedule date

### DIFF
--- a/src/components/TripTable.jsx
+++ b/src/components/TripTable.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import dayjs from 'dayjs';
 import TripTableRow from './TripTableRow';
 import TripTableRowEmpty from './TripTableRowEmpty';
 import HidePastTripsToggle from './HidePastTripsToggle';
@@ -10,6 +11,8 @@ function TripTable({
   routeTrips, route, tripUpdates, scheduleDate, handleDateFieldChange, isLoadingTripDate,
 }) {
   const [hidePastTrips, setHidePastTrips] = useState(true);
+  const isScheduleDateToday = !scheduleDate || scheduleDate === dayjs().format('YYYY-MM-DD');
+  const effectiveHidePastTrips = isScheduleDateToday && hidePastTrips;
 
   if (routeTrips.length === 0) {
     return (
@@ -38,7 +41,9 @@ function TripTable({
     <>
       <div className="d-flex align-items-center mb-2">
         <div className="flex-grow-1">
-          <HidePastTripsToggle hidePastTrips={hidePastTrips} onChange={handleCheckboxChange} />
+          {isScheduleDateToday && (
+            <HidePastTripsToggle hidePastTrips={hidePastTrips} onChange={handleCheckboxChange} />
+          )}
         </div>
         <div>
           {typeof handleDateFieldChange === 'function' && (
@@ -62,7 +67,7 @@ function TripTable({
             <tbody>
               {routeTrips.filter((t) => t.direction_id === '1').map((item, _index) => {
                 const tripUpdate = tripUpdates.find((i) => item.trip_gid === i.trip_update.trip.trip_id) || {};
-                return (<TripTableRow key={item.id} trip={item} route={route} hidePastTrips={hidePastTrips} tripUpdate={tripUpdate}></TripTableRow>);
+                return (<TripTableRow key={item.id} trip={item} route={route} hidePastTrips={effectiveHidePastTrips} isScheduleDateToday={isScheduleDateToday} tripUpdate={tripUpdate}></TripTableRow>);
               })}
               {routeTrips.filter((t) => t.direction_id === '1').length === 0
                 && (<TripTableRowEmpty/>)
@@ -85,7 +90,7 @@ function TripTable({
             <tbody>
               {routeTrips.filter((t) => t.direction_id !== '1').map((item, _index) => {
                 const tripUpdate = tripUpdates.find((i) => item.trip_gid === i.trip_update.trip.trip_id) || {};
-                return (<TripTableRow key={item.id} trip={item} route={route} hidePastTrips={hidePastTrips} tripUpdate={tripUpdate}></TripTableRow>);
+                return (<TripTableRow key={item.id} trip={item} route={route} hidePastTrips={effectiveHidePastTrips} isScheduleDateToday={isScheduleDateToday} tripUpdate={tripUpdate}></TripTableRow>);
               })}
               {routeTrips.filter((t) => t.direction_id !== '1').length === 0 && (
                 <TripTableRowEmpty />

--- a/src/components/TripTable.test.jsx
+++ b/src/components/TripTable.test.jsx
@@ -25,6 +25,17 @@ test('renders TripTable', () => {
   expect(container).toMatchSnapshot();
 });
 
+test('does not show hide-past-trips toggle or filter trips when scheduleDate is not today', () => {
+  MockDate.set('Fri Jul 22 2022 12:10:00 GMT-0500');
+  render(
+    <TripTable routeTrips={routeTripsFixture.data} route={routeFixture} scheduleDate="2022-07-01" />,
+  );
+
+  expect(screen.queryByRole('checkbox', { name: /Hide past trips/i })).not.toBeInTheDocument();
+  expect(screen.getByText('266924')).toBeInTheDocument();
+  expect(screen.getByText('11:26 AM')).toBeInTheDocument();
+});
+
 test('renders TripTable with past trips', async () => {
   MockDate.set('Sun Jul 24 2022 12:10:00 GMT-0500');
   const user = userEvent.setup();

--- a/src/components/TripTableRow.jsx
+++ b/src/components/TripTableRow.jsx
@@ -14,7 +14,7 @@ import Headsign from './Headsign';
 import './TripTableRow.scss';
 
 function TripTableRow({
-  trip, route, tripUpdate, hidePastTrips,
+  trip, route, tripUpdate, hidePastTrips, isScheduleDateToday,
 }) {
   const bikes_allowed_icon = (trip.bikes_allowed !== '1')
     ? (<span className="text-danger"><FontAwesomeIcon icon={faBan} fixedWidth={true}></FontAwesomeIcon></span>)
@@ -60,7 +60,7 @@ function TripTableRow({
   scheduleStatus = getTripScheduleStatus(tripUpdate, trip.stop_times.length);
 
   let rowClasses = '';
-  const isActive = trip.start_time && trip.end_time && isTimeRangeIncludesNow(trip.start_time, trip.end_time);
+  const isActive = isScheduleDateToday && trip.start_time && trip.end_time && isTimeRangeIncludesNow(trip.start_time, trip.end_time);
   const hasFutureEnd = isStopTimeUpdateLaterThanNow(lastStopTime, updateEnd);
   const hasFutureStart = trip.start_time ? isTimeLaterThanNow(trip.start_time) : false;
 
@@ -70,7 +70,9 @@ function TripTableRow({
     if (hidePastTrips) {
       return;
     }
-    rowClasses = 'tr-past-trip';
+    if (isScheduleDateToday) {
+      rowClasses = 'tr-past-trip';
+    }
   }
 
   return (
@@ -141,6 +143,7 @@ TripTableRow.propTypes = {
   route: PropTypes.object.isRequired,
   tripUpdate: PropTypes.object,
   hidePastTrips: PropTypes.bool,
+  isScheduleDateToday: PropTypes.bool,
 };
 
 TripTableRow.defaultProps = {
@@ -148,6 +151,7 @@ TripTableRow.defaultProps = {
   route: {},
   tripUpdate: {},
   hidePastTrips: false,
+  isScheduleDateToday: true,
 };
 
 export default TripTableRow;

--- a/src/components/TripTableRow.test.jsx
+++ b/src/components/TripTableRow.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import MockDate from 'mockdate';
 import TripTableRow from './TripTableRow';
 
 const mockTrip = {
@@ -23,6 +24,36 @@ const mockRoute = {
 };
 
 describe('TripTableRow', () => {
+  afterEach(() => {
+    MockDate.reset();
+  });
+
+  test('does not apply tr-active-trip styling when isScheduleDateToday is false', () => {
+    MockDate.set('Fri Jul 22 2022 10:30:00 GMT-0500');
+    const { container } = render(
+      <table>
+        <tbody>
+          <TripTableRow trip={mockTrip} route={mockRoute} tripUpdate={{}} hidePastTrips={false} isScheduleDateToday={false} />
+        </tbody>
+      </table>,
+    );
+    const row = container.querySelector('tr');
+    expect(row.className).toBe('');
+  });
+
+  test('does not apply tr-past-trip styling when isScheduleDateToday is false', () => {
+    MockDate.set('Fri Jul 22 2022 12:00:00 GMT-0500');
+    const { container } = render(
+      <table>
+        <tbody>
+          <TripTableRow trip={mockTrip} route={mockRoute} tripUpdate={{}} hidePastTrips={false} isScheduleDateToday={false} />
+        </tbody>
+      </table>,
+    );
+    const row = container.querySelector('tr');
+    expect(row.className).toBe('');
+  });
+
   test('renders without crashing', () => {
     const { container } = render(
       <table>

--- a/src/controllers/Trip.jsx
+++ b/src/controllers/Trip.jsx
@@ -208,6 +208,13 @@ function Trip() {
               <th className="text-nowrap align-middle" style={{ width: '130px' }}><FontAwesomeIcon icon={faMap} fixedWidth={true}></FontAwesomeIcon> Trip</th>
               <td>
                 {trip.trip_gid}
+                {trip.scheduled_today === false && (
+                  <OverlayTrigger placement='top' overlay={<Tooltip>This trip is not scheduled to run today</Tooltip>}>
+                    <span className="badge bg-secondary text-white ms-1">
+                      <FontAwesomeIcon icon={faExclamationTriangle} fixedWidth={true} /> Not Running Today
+                    </span>
+                  </OverlayTrigger>
+                )}
                 {tripScheduleStatus === 'canceled' && (
                   <OverlayTrigger placement='top' overlay={<Tooltip>This trip has been canceled</Tooltip>}>
                     <span className="badge bg-danger text-white ms-1">
@@ -229,7 +236,7 @@ function Trip() {
                     </span>
                   </OverlayTrigger>
                 )}
-                {tripScheduleStatus === 'no-data' && (
+                {tripScheduleStatus === 'no-data' && trip.scheduled_today !== false && (
                   <OverlayTrigger placement='top' overlay={<Tooltip>No real-time data for this trip</Tooltip>}>
                     <span className="badge bg-secondary text-white ms-1">
                       <FontAwesomeIcon icon={faExclamationTriangle} fixedWidth={true} /> No Data

--- a/src/controllers/Trip.jsx
+++ b/src/controllers/Trip.jsx
@@ -210,7 +210,7 @@ function Trip() {
                 {trip.trip_gid}
                 {trip.scheduled_today === false && (
                   <OverlayTrigger placement='top' overlay={<Tooltip>This trip is not scheduled to run today</Tooltip>}>
-                    <span className="badge bg-secondary text-white ms-1">
+                    <span className="badge bg-danger text-white ms-1">
                       <FontAwesomeIcon icon={faExclamationTriangle} fixedWidth={true} /> Not Running Today
                     </span>
                   </OverlayTrigger>
@@ -291,7 +291,9 @@ function Trip() {
           </tbody>
         </table>
 
-        <TripProgressBar trip={trip} tripUpdates={filteredTripUpdates}></TripProgressBar>
+        {trip.scheduled_today !== false && (
+          <TripProgressBar trip={trip} tripUpdates={filteredTripUpdates}></TripProgressBar>
+        )}
 
         <TransitMap vehicleMarkers={filteredVehicleMarkers} routes={[route]} agencies={agencies} routeShapes={[trip.shape]} routeStops={trip.stop_times} alerts={allAlerts} tripUpdates={tripUpdates} map={map} center={[center.lat, center.lng]} zoom={13}></TransitMap>
         <AlertList alerts={routeAlerts} routes={[route]} showHorizontal></AlertList>


### PR DESCRIPTION
## Summary
- On a route page, the "hide past trips" toggle and the tr-past-trip/tr-active-trip row styling compared trip times to the current clock time regardless of the selected schedule date. Viewing a non-today date produced misleading past/active indicators. Both now only apply when the selected date is today; the toggle is hidden on other dates.
- Adds a "Not Running Today" badge on the trip page when the API reports `scheduled_today: false`, now that `GET /trips/:id` can return trips that aren't scheduled for the current service day (see transitnownash/gtfs-rails-api#155).

## Test plan
- [x] `npm run lint`
- [x] `npm test` (105 tests)
- [ ] Requires transitnownash/gtfs-rails-api#155 to be merged/deployed for the "Not Running Today" badge to actually appear (field is simply absent/undefined otherwise, so it degrades gracefully).

🤖 Generated with [Claude Code](https://claude.com/claude-code)